### PR TITLE
Update build badge to point to team repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![CI Status](https://github.com/AY2526S1-CS2103T-F12-4/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2526S1-CS2103T-F12-4/tp/actions)
 
 ![Ui](docs/images/Ui.png)
 


### PR DESCRIPTION
Fixes #27

Update the Build Status badge in README.md to point to our team repo's GitHub Actions workflow.